### PR TITLE
Add session limit middleware tests

### DIFF
--- a/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/config/settings/base.py
+++ b/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/config/settings/base.py
@@ -148,6 +148,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "{{ cookiecutter.project_slug }}.utils.session_limit.ActiveSessionMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/env.example
+++ b/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/env.example
@@ -19,3 +19,6 @@ DJANGO_SECURE_SSL_REDIRECT=False
 
 # Are we using Vagrant
 USE_VAGRANT=
+
+# Redis location for session tracking
+REDIS_URL=redis://redis:6379/1

--- a/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/__init__.py
+++ b/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/__init__.py
@@ -1,0 +1,1 @@
+from .session_limit import ActiveSessionMiddleware

--- a/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/session_limit.py
+++ b/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/session_limit.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import logout
+from django.http import HttpResponseForbidden
+from django_redis import get_redis_connection
+
+
+class ActiveSessionMiddleware:
+    """Record active session IPs in Redis and limit concurrent sessions."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.redis = get_redis_connection("default")
+
+    def __call__(self, request):
+        response = self.process_request(request)
+        if response:
+            return response
+        response = self.get_response(request)
+        return response
+
+    def process_request(self, request):
+        user = getattr(request, "user", None)
+        if user and user.is_authenticated:
+            session_key = request.session.session_key
+            if not session_key:
+                request.session.save()
+                session_key = request.session.session_key
+            key = f"active_sessions:{user.pk}"
+            ip = self._get_client_ip(request)
+            pipe = self.redis.pipeline()
+            pipe.hset(key, session_key, ip)
+            pipe.hlen(key)
+            pipe.expire(key, request.session.get_expiry_age())
+            _, count, _ = pipe.execute()
+            if count > 20:
+                self.redis.hdel(key, session_key)
+                logout(request)
+                return HttpResponseForbidden("Too many active sessions")
+        return None
+
+    def _get_client_ip(self, request):
+        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if x_forwarded_for:
+            ip = x_forwarded_for.split(",")[0].strip()
+        else:
+            ip = request.META.get("REMOTE_ADDR")
+        return ip
+

--- a/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/tests/test_session_limit.py
+++ b/templates/sixfeetup-fullstack/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/tests/test_session_limit.py
@@ -1,0 +1,102 @@
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.contrib.sessions.middleware import SessionMiddleware
+
+from {{ cookiecutter.project_slug }}.utils.session_limit import ActiveSessionMiddleware
+
+
+class FakePipeline:
+    def __init__(self, redis):
+        self.redis = redis
+        self.commands = []
+
+    def hset(self, key, field, value):
+        self.commands.append(("hset", key, field, value))
+        return 1
+
+    def hlen(self, key):
+        self.commands.append(("hlen", key))
+        return len(self.redis.store.get(key, {}))
+
+    def expire(self, key, timeout):
+        self.commands.append(("expire", key, timeout))
+        return True
+
+    def execute(self):
+        results = []
+        count = 0
+        for cmd in self.commands:
+            if cmd[0] == "hset":
+                _, key, field, value = cmd
+                self.redis.store.setdefault(key, {})[field] = value
+                results.append(1)
+            elif cmd[0] == "hlen":
+                _, key = cmd
+                count = len(self.redis.store.get(key, {}))
+                results.append(count)
+            elif cmd[0] == "expire":
+                results.append(True)
+        self.commands = []
+        return results
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def pipeline(self):
+        return FakePipeline(self)
+
+    def hdel(self, key, field):
+        if key in self.store:
+            self.store[key].pop(field, None)
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    r = FakeRedis()
+    monkeypatch.setattr(
+        "{{ cookiecutter.project_slug }}.utils.session_limit.get_redis_connection",
+        lambda *_args, **_kwargs: r,
+    )
+    return r
+
+
+@pytest.mark.django_db
+def test_record_ip(fake_redis, rf: RequestFactory, user):
+    middleware = ActiveSessionMiddleware(lambda r: HttpResponse("OK"))
+
+    request = rf.get("/", REMOTE_ADDR="127.0.0.1")
+    request.user = user
+
+    sm = SessionMiddleware(lambda r: None)
+    sm.process_request(request)
+    request.session.save()
+
+    response = middleware(request)
+
+    assert response.status_code == 200
+    key = f"active_sessions:{user.pk}"
+    assert fake_redis.store[key][request.session.session_key] == "127.0.0.1"
+
+
+@pytest.mark.django_db
+def test_limit_exceeded(fake_redis, rf: RequestFactory, user):
+    key = f"active_sessions:{user.pk}"
+    fake_redis.store[key] = {f"s{i}": "ip" for i in range(20)}
+
+    middleware = ActiveSessionMiddleware(lambda r: HttpResponse("OK"))
+
+    request = rf.get("/", REMOTE_ADDR="127.0.0.2")
+    request.user = user
+
+    sm = SessionMiddleware(lambda r: None)
+    sm.process_request(request)
+    request.session.save()
+
+    response = middleware(request)
+
+    assert response.status_code == 403
+    assert len(fake_redis.store[key]) == 20
+    assert request.session.session_key not in fake_redis.store[key]


### PR DESCRIPTION
## Summary
- add tests for ActiveSessionMiddleware session tracking and limit enforcement

## Testing
- `pytest -q` *(fails: SyntaxError from cookiecutter template files)*